### PR TITLE
Improve feed count performance

### DIFF
--- a/src/ItemBrowser.js
+++ b/src/ItemBrowser.js
@@ -353,11 +353,11 @@ function ItemBrowser(props) {
 				entry_ids: i.map((x) => x.id),
 				status: read || read === undefined ? 'read' : 'unread',
 			})
-			props.updateUnread(
-				i
-					.map((x) => x.feed.id)
-					.filter((f, index, self) => self.indexOf(f) === index)
-			)
+			props.feeds
+				.filter((f) => i.map((x) => x.feed_id).indexOf(f.id) !== -1)
+				.map(
+					(f) => (f['unreads'] += read || read === undefined ? -1 : 1)
+				)
 
 			const currItems = items
 			i.forEach(
@@ -366,6 +366,8 @@ function ItemBrowser(props) {
 						read || read === undefined ? 'read' : 'unread')
 			)
 			setItems(currItems)
+
+			props.refreshFeedCounts()
 		}
 	}
 	return (


### PR DESCRIPTION
Hi !

I have a collection of 200+ feeds and I have noticed a performance issue caused by the unread count (one ajax call and one state refresh per feed). 

This PR is using the new endpoint [/feeds/fetch-counters](https://github.com/miniflux/v2/pull/1431) that will be available on miniflux to return the unread count in one call, it includes a fallback for older version of the miniflux backend and a refactoring to avoid the refresh performance hog.

Regards,
Pascal Noisette